### PR TITLE
fixed Redis gem issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
+    redis (4.8.0)
     regexp_parser (2.6.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -213,6 +214,7 @@ DEPENDENCIES
   jbuilder
   puma (~> 5.0)
   rails (~> 7.0.4)
+  redis (~> 4.0)
   selenium-webdriver
   sprockets-rails
   sqlite3 (~> 1.4)


### PR DESCRIPTION
Redis gem not installing issue fixed. 

Cause: 
 - if no Redis server is running locally, there was an issue in installing the Redis gem.

Fixes:
- started the Redis server and installed the gem.